### PR TITLE
Mac friendly use of /dev/urandom

### DIFF
--- a/articles/day.25.build.pipes.key.vault.linux.md
+++ b/articles/day.25.build.pipes.key.vault.linux.md
@@ -44,7 +44,7 @@ You should get back the following output.
 Next, run the following command randomly generate 4 alphanumeric characters.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 > **NOTE:** We are appending this to the name of our Key Vault to ensure its name is unique.

--- a/articles/day.28.build.pipes.sp.direct.access.to.key.vault.linux.md
+++ b/articles/day.28.build.pipes.sp.direct.access.to.key.vault.linux.md
@@ -43,7 +43,7 @@ You should get back the following output.
 Next, run the following command randomly generate 4 alphanumeric characters.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 > **NOTE:** We are appending this to the name of our Key Vault to ensure its name is unique.

--- a/articles/day.30.build.pipes.encrypted.variables.linux.md
+++ b/articles/day.30.build.pipes.encrypted.variables.linux.md
@@ -46,7 +46,7 @@ You should get back the following output:
 Next, run the following command randomly generate 4 alphanumeric characters.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 > **NOTE:** We are appending this to the name of our Storage Account to ensure we create a unique Storage Account name.

--- a/articles/day.31.build.pipes.sp.managed.sql.linux.md
+++ b/articles/day.31.build.pipes.sp.managed.sql.linux.md
@@ -45,7 +45,7 @@ You should get back the following output:
 Next, run the following command randomly generate 4 alphanumeric characters.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 > **NOTE:** We are appending this to the name of our Azure SQL Server and DB to ensure uniqueness.

--- a/articles/day.72.deploying.private.k8s.clusters.in.azure.part1.md
+++ b/articles/day.72.deploying.private.k8s.clusters.in.azure.part1.md
@@ -115,7 +115,7 @@ AZURE_SUB_ID="00000000-0000-0000-0000-000000000000"
 Next, run the following command randomly generate 4 alphanumeric characters. This will be appended to the name of the Kubernetes Cluster for uniqueness.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 </br>

--- a/articles/day.xx.building.and.deploying.containers.part1.md
+++ b/articles/day.xx.building.and.deploying.containers.part1.md
@@ -87,7 +87,7 @@ You should get back the following output:
 Next, run the following command randomly generate 4 alphanumeric characters.
 
 ```bash
-RANDOM_ALPHA=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+RANDOM_ALPHA=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 4 | head -n 1)
 ```
 
 > **NOTE:** We are appending this to the name of our Container Registry to ensure we create a unique name.


### PR DESCRIPTION
Because of the way Mac handles unicode characters, the original script will complain of an illegal byte sequence. 

More information can be found here: http://nerdbynature.de/s9y/2010/04/11/tr-Illegal-byte-sequence

I've tested the proposed change on both Mac and WSL and it works in both cases.